### PR TITLE
Bump ddev-gitpod-base image to 20231213, v1.22.6

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ddev/ddev-gitpod-base:20231127
+image: ddev/ddev-gitpod-base:20231213
 
 tasks:
   - name: ddev-gitpod-launcher


### PR DESCRIPTION
## The Issue

DDEV v1.22.6 is out.

## How This PR Solves The Issue

Push new gitpod image.
