### PR TITLE
Update script.js to fix bug with artifacts URL, fixes #30

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -38,6 +38,7 @@ document.body.onload = () => {
   })
   document.getElementById('ddev-repo').addEventListener('change', (e) => {
       updateArtifacts();
+      computeLink();
     })
 
 }


### PR DESCRIPTION
## The Issue
See #30.

## How This PR Solves The Issue
I _think_ that all that is needed is an additional `computeLink();` call, as I added in this PR, but additional testings by others is more than welcome.

## Manual Testing Instructions
Use a custom repository and artifacts URL  (not `d10simple`) and ensure it works.

-mike