### PR TITLE
Bump ddev-gitpod-base image to 20240417, v1.23.0

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ddev/ddev-gitpod-base:20240207
+image: ddev/ddev-gitpod-base:20240417
 
 tasks:
   - name: ddev-gitpod-launcher


### PR DESCRIPTION
## The Issue

DDEV v1.23.0 is out.

## How This PR Solves The Issue

Pushes a new Gitpod image.