### PR TITLE
Bump ddev-gitpod-base image to 20240516, v1.23.1

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ddev/ddev-gitpod-base:20240426
+image: ddev/ddev-gitpod-base:20240516
 
 tasks:
   - name: ddev-gitpod-launcher


### PR DESCRIPTION
## The Issue

DDEV v1.23.1 is out.

## How This PR Solves The Issue

Pushes a new Gitpod image.
