### PR TITLE
Update mailpit port

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -35,11 +35,8 @@ ports:
   # Used by projector
   - port: 6942
     onOpen: ignore
-  # Currently un-notified and unsupported mailhog http port
-  - port: 8025
-    onOpen: ignore
-  # Currently un-notified and unsupported mailhog https port
-  - port: 8026
+  # Currently un-notified and unsupported mailpit https port
+  - port: 8027
     onOpen: ignore
   # Currently un-notified and unsupported phpmyadmin http port
   - port: 8036


### PR DESCRIPTION
## The Issue

Currently Gitpod config uses `8025`, `8026` ports for Mailpit.

## How This PR Solves The Issue

Update to use `8027`.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

