### PR TITLE
Update Gitpod ports

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -47,7 +47,7 @@ ports:
   - port: 8080
     onOpen: ignore
   # xdebug port
-  - port: 9000
+  - port: 9003
     onOpen: ignore
   # projector port
   - port: 9999

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -51,5 +51,8 @@ ports:
   # xdebug port
   - port: 9003
     onOpen: ignore
+  # Adminer
+  - port: 9101
+    onOpen: ignore
   # projector port
   - port: 9999

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -48,6 +48,9 @@ ports:
   # Direct-connect ddev-webserver port that is the main port
   - port: 8080
     onOpen: ignore
+  # xhgui port
+  - port: 8142
+    onOpen: ignore
   # xdebug port
   - port: 9003
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -57,7 +57,10 @@ ports:
   # xdebug port
   - port: 9003
     onOpen: ignore
-  # Adminer
+  # Adminer http port
+  - port: 9100
+    onOpen: ignore
+  # Adminer https port
   - port: 9101
     onOpen: ignore
   # projector port

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -46,12 +46,6 @@ ports:
   # Direct-connect ddev-webserver port that is the main port
   - port: 8080
     onOpen: ignore
-  # router http port that we're ignoring.
-  - port: 8888
-    onOpen: ignore
-  # router https port that we're ignoring.
-  - port: 8889
-    onOpen: ignore
   # xdebug port
   - port: 9000
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -48,7 +48,10 @@ ports:
   # Direct-connect ddev-webserver port that is the main port
   - port: 8080
     onOpen: ignore
-  # xhgui port
+  # xhgui http port
+  - port: 8143
+    onOpen: ignore
+  # xhgui https port
   - port: 8142
     onOpen: ignore
   # xdebug port

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -28,6 +28,8 @@ ports:
     onOpen: ignore
   - port: 3306
     onOpen: ignore
+  - port: 5432
+    onOpen: ignore
   # Used by projector
   - port: 6942
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -31,9 +31,6 @@ ports:
   # Used by projector
   - port: 6942
     onOpen: ignore
-  # Direct-connect ddev-webserver port that is the main port
-  - port: 8080
-    onOpen: ignore
   # Currently un-notified and unsupported mailhog http port
   - port: 8025
     onOpen: ignore
@@ -45,6 +42,9 @@ ports:
     onOpen: ignore
   # Currently un-notified and unsupported phpmyadmin https port
   - port: 8037
+    onOpen: ignore
+  # Direct-connect ddev-webserver port that is the main port
+  - port: 8080
     onOpen: ignore
   # router http port that we're ignoring.
   - port: 8888


### PR DESCRIPTION
## The Issue
I was debugging Mailpit issues in Gitpod when I noticed many of the ports are outdated.

## How This PR Solves The Issue
This PR 

- updates the ports to match those from
https://github.com/ddev/ddev/blob/master/.gitpod.yml
- adds postgres port

This PR does NOT update the Mailpit port. See #40

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

