### PR TITLE
Update ddev in gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,6 +5,7 @@ tasks:
     before: |
       mkdir /workspace/code -p
     init: |
+      sudo apt-get update && sudo apt install -y ddev
       ddev debug download-images
     command: |
       export DDEV_NONINTERACTIVE=true


### PR DESCRIPTION
## The Issue

We've been having to push a new image with DDEV bundled on every DDEV release, but it's really not necessary, and better to just do the upgrade here.

## How This PR Solves The Issue

Do apt update and apt upgrade ddev

## Manual Testing Instructions

See docs in https://github.com/ddev/ddev-gitpod-launcher#test-a-branch-of-this-repo

The branch is rfay:20240703_update_ddev: (https://github.com/rfay/ddev-gitpod-launcher/tree/20240703_update_ddev)

So:

1. Visit <https://ddev.github.io/ddev-gitpod-launcher/>.
2. Enter target repo.
3. Copy the "Link used by "Open in Gitpod" button:" URL
4. Replace `https://github.com/ddev/ddev-gitpod-launcher/` with the branch path Eg. `https://github.com/rfay/ddev-gitpod-launcher/tree/20240703_update_ddev`

Actually, just use this link:

https://gitpod.io/?autostart=true#DDEV_REPO=https%3A%2F%2Fgithub.com%2Fddev%2Fd10simple,DDEV_ARTIFACTS=https%3A%2F%2Fgithub.com%2Fddev%2Fd10simple-artifacts/https://github.com/rfay/ddev-gitpod-launcher/tree/20240703_update_ddev



