### PR TITLE
Omit ddev-router on init

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,6 +6,7 @@ tasks:
       mkdir /workspace/code -p
     init: |
       sudo apt-get update && sudo apt install -y ddev
+      ddev config global --omit-containers=ddev-router
       ddev debug download-images
     command: |
       export DDEV_NONINTERACTIVE=true


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev/pull/6390

`/workspace` appears to be a special folder that is overridden by Gitpod.
It doesn't pick up any content from the pre-built Docker image.

## How This PR Solves The Issue

That's why we need to omit `ddev-router` on the Gitpod init.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

